### PR TITLE
Try to prevent creating node parent references to itself

### DIFF
--- a/app/Http/Controllers/ModuleController.php
+++ b/app/Http/Controllers/ModuleController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Log;
 use ZipArchive;
 use File;
 use Response;
@@ -123,6 +124,10 @@ class ModuleController extends Controller
         }
 
     	foreach($module->nodes as $node) {
+            if($node->parent && $node->id == $node->parent->id) {
+                $node->parent()->dissociate(); //Remove circular reference
+                Log::info('Removed a circular reference in module ' . $module->id . ' for node ' . $node->id);
+            }
     		if( $request->has('node_sort_order_' . $node->id)) {
     			$node->sort_order = $request->input('node_sort_order_' . $node->id);
     			$node->save();

--- a/app/Http/Controllers/NodeController.php
+++ b/app/Http/Controllers/NodeController.php
@@ -187,7 +187,7 @@ class NodeController extends Controller
     // TODO: Edit the slot for this node as well (remove, if ancestor has a slot, always?)
     public function moveToTargetNode( Node $node, Node $targetnode = null) { 
         $this->authorize('update', $node);
-        if($targetnode) {
+        if($targetnode && $targetnode->id != $node->id) {
             $node->parent()->associate($targetnode);
         } else {
             $node->parent()->dissociate();
@@ -200,10 +200,12 @@ class NodeController extends Controller
 
     public function moveToTargetSlot( Node $node, LayoutSlot $targetslot, $position = 'top' ) { 
         $this->authorize('update', $node);
-        $node->layoutSlot()->associate($targetslot);
         // Set parent to the first ancestor that's a page, because a node 
         // directly in a layout slot is always a child of the page.
-        $node->parent()->associate($node->page());
+        if($node->page()->id != $node->id) {
+            $node->parent()->associate($node->page());
+            $node->layoutSlot()->associate($targetslot);
+        }
         if($position == 'top') {
             $node->sort_order = 0;
         } else {

--- a/app/Node.php
+++ b/app/Node.php
@@ -312,6 +312,7 @@ class Node extends Model {
 		$descendants = $this->children->load(['children', 'block']);
 		if($this->children) {
 			foreach($this->children as $child) {
+				if($this->child->id == $this->id) { continue; } //Prevent running through circular references
 				$descendants = $descendants->merge($child->descendants());
 			}
 		}


### PR DESCRIPTION
It was possible to move a node to 'itself', creating a parent reference to itself. When opening this node, or exporting the module, this led to an infinite loop, exhausting all available memory. This attempts to prevent that from occurring. Existing circular references are checked when saving modules, and removed.